### PR TITLE
fix: update TestFlight upload action version and add retry options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,14 @@ jobs:
                     -exportPath $RUNNER_TEMP/build | xcpretty
 
       - name: Upload IPA to TestFlight
-        uses: apple-actions/upload-testflight@v1
+        uses: apple-actions/upload-testflight@v1.1.0
         with:
           app-path: ${{ runner.temp }}/build/ParentingAssistant.ipa
           api-key: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
           api-key-id: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           api-issuer: ${{ secrets.APP_STORE_CONNECT_API_ISSUER }}
+          skip-waiting: true
+          retry-times: 3
 
       - name: Upload dSYM Files
         run: |


### PR DESCRIPTION
This pull request includes an update to the `jobs:` section in the `.github/workflows/ci.yml` file to improve the TestFlight upload process.

Improvements to TestFlight upload:

* Updated the `apple-actions/upload-testflight` action from version `v1` to `v1.1.0`.
* Added `skip-waiting: true` to the TestFlight upload step to skip the waiting period after uploading.
* Added `retry-times: 3` to the TestFlight upload step to retry the upload up to three times in case of failure.