### PR TITLE
add google sign

### DIFF
--- a/ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj
+++ b/ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		FA7706852D8C8433007C0351 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = FA7706842D8C8433007C0351 /* FirebaseCrashlytics */; };
+		FAA41C6D2D9330660037154A /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = FAA41C6C2D9330660037154A /* GoogleSignIn */; };
+		FAA41C6F2D9330660037154A /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = FAA41C6E2D9330660037154A /* GoogleSignInSwift */; };
 		FAA887462D7AC5A700639E34 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = FAA887452D7AC5A700639E34 /* FirebaseAnalytics */; };
 		FAA887482D7AC5A700639E34 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = FAA887472D7AC5A700639E34 /* FirebaseAuth */; };
 		FAA8874A2D7AC5A700639E34 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = FAA887492D7AC5A700639E34 /* FirebaseFirestore */; };
@@ -77,9 +79,11 @@
 			files = (
 				FAFAE0442D834D1B0042C3B4 /* FirebaseMessaging in Frameworks */,
 				FAA887462D7AC5A700639E34 /* FirebaseAnalytics in Frameworks */,
+				FAA41C6F2D9330660037154A /* GoogleSignInSwift in Frameworks */,
 				FA7706852D8C8433007C0351 /* FirebaseCrashlytics in Frameworks */,
 				FAA887482D7AC5A700639E34 /* FirebaseAuth in Frameworks */,
 				FAA8874A2D7AC5A700639E34 /* FirebaseFirestore in Frameworks */,
+				FAA41C6D2D9330660037154A /* GoogleSignIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -155,6 +159,8 @@
 				FAA887492D7AC5A700639E34 /* FirebaseFirestore */,
 				FAFAE0432D834D1B0042C3B4 /* FirebaseMessaging */,
 				FA7706842D8C8433007C0351 /* FirebaseCrashlytics */,
+				FAA41C6C2D9330660037154A /* GoogleSignIn */,
+				FAA41C6E2D9330660037154A /* GoogleSignInSwift */,
 			);
 			productName = ParentingAssistant;
 			productReference = FA0D6E3D2D7A24AF00AF0365 /* ParentingAssistant.app */;
@@ -240,6 +246,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				FA0D6EAD2D7ABF6400AF0365 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				FAA41C6B2D93304E0037154A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = FA0D6E3E2D7A24AF00AF0365 /* Products */;
@@ -300,8 +307,7 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"";
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n";
+			shellScript = "# Dynamically compute the base directory where SPM packages are checked out.\nSCRIPT_BASE=\"${BUILT_PRODUCTS_DIR%/Build/Products*}\"\nSCRIPT_PATH=\"${SCRIPT_BASE}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n\necho \"Resolved Crashlytics run script path: ${SCRIPT_PATH}\"\n\nif [ -f \"${SCRIPT_PATH}\" ]; then\n  # Ensure the script is executable.\n  chmod +x \"${SCRIPT_PATH}\"\n  # Execute the Crashlytics run script.\n  \"${SCRIPT_PATH}\"\nelse\n  echo \"Error: Crashlytics run script not found at: ${SCRIPT_PATH}\"\n  # For debugging: list the checkout directories.\n  echo \"Listing SourcePackages directory for firebase-ios-sdk:\"\n  find \"${SCRIPT_BASE}/SourcePackages/checkouts\" -type d -name \"firebase-ios-sdk\" -print\n  exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -680,6 +686,14 @@
 				minimumVersion = 11.9.0;
 			};
 		};
+		FAA41C6B2D93304E0037154A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -687,6 +701,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = FA0D6EAD2D7ABF6400AF0365 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCrashlytics;
+		};
+		FAA41C6C2D9330660037154A /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FAA41C6B2D93304E0037154A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+		FAA41C6E2D9330660037154A /* GoogleSignInSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FAA41C6B2D93304E0037154A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignInSwift;
 		};
 		FAA887452D7AC5A700639E34 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/ParentingAssistant/ParentingAssistant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ParentingAssistant/ParentingAssistant.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
+  "originHash" : "809767c578f1058ab5fea90c3e19b6cd2d1f9dd10190023753094a356e675446",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
         "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
       }
     },
     {
@@ -47,6 +56,15 @@
       }
     },
     {
+      "identity" : "googlesignin-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleSignIn-iOS.git",
+      "state" : {
+        "revision" : "65fb3f1aa6ffbfdc79c4e22178a55cd91561f5e9",
+        "version" : "8.0.0"
+      }
+    },
+    {
       "identity" : "googleutilities",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
@@ -69,8 +87,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "4d70340d55d7d07cc2fdf8e8125c4c126c1d5f35",
-        "version" : "4.4.0"
+        "revision" : "a2ab612cb980066ee56d90d60d8462992c07f24b",
+        "version" : "3.5.0"
+      }
+    },
+    {
+      "identity" : "gtmappauth",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GTMAppAuth.git",
+      "state" : {
+        "revision" : "5d7d66f647400952b1758b230e019b07c0b4b22a",
+        "version" : "4.1.1"
       }
     },
     {

--- a/ParentingAssistant/ParentingAssistant/Info.plist
+++ b/ParentingAssistant/ParentingAssistant/Info.plist
@@ -48,5 +48,16 @@
         <string>UIInterfaceOrientationLandscapeLeft</string>
         <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
-</dict>
+    </dict>
+    <key>CFBundleURLTypes</key>
+    <array>
+    <dict>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>com.googleusercontent.apps.946865924755-nahs4k40jlmerbvtgv6skuh949ja94j1</string>
+        </array>
+        <key>CFBundleURLName</key>
+        <string>com.yourcompany.parentingassistant</string>
+    </dict>
+    </array>
 </plist> 


### PR DESCRIPTION
This pull request includes several changes to the `ParentingAssistant` project, primarily focused on adding support for Google Sign-In and improving the build script for Crashlytics. The most important changes are listed below.

### Integration of Google Sign-In:

* Added `GoogleSignIn` and `GoogleSignInSwift` frameworks to the project build files. [[1]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R11-R12) [[2]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R82-R86) [[3]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R162-R163)
* Added a new package reference for `GoogleSignIn-iOS` in the project configuration. [[1]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R249) [[2]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R689-R696)
* Updated the `Package.resolved` file to include `googlesignin-ios`, `appauth-ios`, and `gtmappauth` dependencies. [[1]](diffhunk://#diff-4a71c3a6b892f66be3797d8e3291e9a73b1b769051f45246b6d852a6a593987cR22-R30) [[2]](diffhunk://#diff-4a71c3a6b892f66be3797d8e3291e9a73b1b769051f45246b6d852a6a593987cR58-R66) [[3]](diffhunk://#diff-4a71c3a6b892f66be3797d8e3291e9a73b1b769051f45246b6d852a6a593987cL72-R100)

### Crashlytics Build Script Improvement:

* Enhanced the Crashlytics run script to dynamically compute the base directory for SPM packages and handle errors more gracefully.

### Configuration Updates:

* Updated the `Info.plist` file to include URL types for Google Sign-In.