### PR TITLE
Fix/firebase crashlytics sandbox

### DIFF
--- a/ParentingAssistant/FirebaseCrashlytics/run
+++ b/ParentingAssistant/FirebaseCrashlytics/run
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Copyright 2019 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# run
+#
+# This script is meant to be run as a Run Script in the "Build Phases" section
+# of your Xcode project. It sends debug symbols to symbolicate stacktraces,
+# sends build events to track versions, and onboards apps for Crashlytics.
+#
+# This script calls upload-symbols twice:
+#
+# 1) First it calls upload-symbols synchronously in "validation" mode. If the
+#    script finds issues with the build environment, it will report errors to Xcode.
+#    In validation mode it exits before doing any time consuming work.
+#
+# 2) Then it calls upload-symbols in the background to actually send the build
+#    event and upload symbols. It does this in the background so that it doesn't
+#    slow down your builds. If an error happens here, you won't see it in Xcode.
+#
+# You can find the output for the background execution in Console.app, by
+# searching for "upload-symbols".
+#
+# If you want verbose output, you can pass the --debug flag to this script
+#
+
+#  Figure out where we're being called from
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+#  Build up the arguments list, passing through any flags added, and quoting
+#  every argument in case there are spaces in any of the paths.
+ARGUMENTS=''
+for i in "$@"; do
+  ARGUMENTS="$ARGUMENTS \"$i\""
+done
+
+VALIDATE_ARGUMENTS="--build-phase --validate $ARGUMENTS"
+UPLOAD_ARGUMENTS="--build-phase $ARGUMENTS "
+
+# Quote the path to handle folders with special characters
+COMMAND_PATH="\"$DIR/upload-symbols\" "
+
+#  Ensure params are as expected, run in sync mode to validate,
+#  and cause a build error if validation fails
+eval $COMMAND_PATH$VALIDATE_ARGUMENTS
+return_code=$?
+
+if [[ $return_code != 0 ]]; then
+  exit $return_code
+fi
+
+#  Verification passed, convert and upload dSYMs in the background to prevent
+#  build delays
+#
+#  Note: Validation is performed again at this step before upload
+#
+#  Note: Output can still be found in Console.app, by searching for
+#        "upload-symbols"
+#
+eval $COMMAND_PATH$UPLOAD_ARGUMENTS > /dev/null 2>&1 &

--- a/ParentingAssistant/FirebaseCrashlytics/run.txt
+++ b/ParentingAssistant/FirebaseCrashlytics/run.txt
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Copyright 2019 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# run
+#
+# This script is meant to be run as a Run Script in the "Build Phases" section
+# of your Xcode project. It sends debug symbols to symbolicate stacktraces,
+# sends build events to track versions, and onboards apps for Crashlytics.
+#
+# This script calls upload-symbols twice:
+#
+# 1) First it calls upload-symbols synchronously in "validation" mode. If the
+#    script finds issues with the build environment, it will report errors to Xcode.
+#    In validation mode it exits before doing any time consuming work.
+#
+# 2) Then it calls upload-symbols in the background to actually send the build
+#    event and upload symbols. It does this in the background so that it doesn't
+#    slow down your builds. If an error happens here, you won't see it in Xcode.
+#
+# You can find the output for the background execution in Console.app, by
+# searching for "upload-symbols".
+#
+# If you want verbose output, you can pass the --debug flag to this script
+#
+
+#  Figure out where we're being called from
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+#  Build up the arguments list, passing through any flags added, and quoting
+#  every argument in case there are spaces in any of the paths.
+ARGUMENTS=''
+for i in "$@"; do
+  ARGUMENTS="$ARGUMENTS \"$i\""
+done
+
+VALIDATE_ARGUMENTS="--build-phase --validate $ARGUMENTS"
+UPLOAD_ARGUMENTS="--build-phase $ARGUMENTS "
+
+# Quote the path to handle folders with special characters
+COMMAND_PATH="\"$DIR/upload-symbols\" "
+
+#  Ensure params are as expected, run in sync mode to validate,
+#  and cause a build error if validation fails
+eval $COMMAND_PATH$VALIDATE_ARGUMENTS
+return_code=$?
+
+if [[ $return_code != 0 ]]; then
+  exit $return_code
+fi
+
+#  Verification passed, convert and upload dSYMs in the background to prevent
+#  build delays
+#
+#  Note: Validation is performed again at this step before upload
+#
+#  Note: Output can still be found in Console.app, by searching for
+#        "upload-symbols"
+#
+eval $COMMAND_PATH$UPLOAD_ARGUMENTS > /dev/null 2>&1 &

--- a/ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj
+++ b/ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj
@@ -315,7 +315,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n# Use the local copy of the Crashlytics run script located in your project.\n# If your Xcode project is in the ParentingAssistant folder, then SRCROOT is that folder.\nSCRIPT_PATH=\"${SRCROOT}/FirebaseCrashlytics/run\"\n\necho \"Resolved Crashlytics run script path: ${SCRIPT_PATH}\"\necho \"Listing contents of ${SRCROOT}/FirebaseCrashlytics:\"\nls -la \"${SRCROOT}/FirebaseCrashlytics\"\n\nif [ -f \"${SCRIPT_PATH}\" ]; then\n  # Ensure the script is executable.\n  chmod +x \"${SCRIPT_PATH}\"\n  echo \"Executing Crashlytics run script...\"\n  \"${SCRIPT_PATH}\"\nelse\n  echo \"Error: Crashlytics run script not found at: ${SCRIPT_PATH}\"\n  exit 1\nfi\n";
+			shellScript = "# Get the path to the Firebase Crashlytics script\nSCRIPT_PATH=\"${BUILD_DIR%Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n\nif [ -f \"${SCRIPT_PATH}\" ]; then\n  echo \"Found Crashlytics script at: ${SCRIPT_PATH}\"\n  \"${SCRIPT_PATH}\" --build-phase\nelse\n  echo \"Error: Crashlytics script not found at: ${SCRIPT_PATH}\"\n  exit 1\nfi\n";
 			disableDefaultSettings = 1;
 			enableUserScriptSandboxing = 0;
 		};

--- a/ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj
+++ b/ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj
@@ -70,6 +70,11 @@
 			path = ParentingAssistantUITests;
 			sourceTree = "<group>";
 		};
+		FA5B19822D935E8C003A8414 /* FirebaseCrashlytics */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = FirebaseCrashlytics;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +112,7 @@
 		FA0D6E342D7A24AF00AF0365 = {
 			isa = PBXGroup;
 			children = (
+				FA5B19822D935E8C003A8414 /* FirebaseCrashlytics */,
 				FAFADF2C2D833C740042C3B4 /* Config.xcconfig */,
 				FA0D6E3F2D7A24AF00AF0365 /* ParentingAssistant */,
 				FA0D6E512D7A24B000AF0365 /* ParentingAssistantTests */,
@@ -151,6 +157,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				FA0D6E3F2D7A24AF00AF0365 /* ParentingAssistant */,
+				FA5B19822D935E8C003A8414 /* FirebaseCrashlytics */,
 			);
 			name = ParentingAssistant;
 			packageProductDependencies = (
@@ -307,7 +314,10 @@
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
-			shellScript = "# Dynamically compute the base directory where SPM packages are checked out.\nSCRIPT_BASE=\"${BUILT_PRODUCTS_DIR%/Build/Products*}\"\nSCRIPT_PATH=\"${SCRIPT_BASE}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n\necho \"Resolved Crashlytics run script path: ${SCRIPT_PATH}\"\n\nif [ -f \"${SCRIPT_PATH}\" ]; then\n  # Ensure the script is executable.\n  chmod +x \"${SCRIPT_PATH}\"\n  # Execute the Crashlytics run script.\n  \"${SCRIPT_PATH}\"\nelse\n  echo \"Error: Crashlytics run script not found at: ${SCRIPT_PATH}\"\n  # For debugging: list the checkout directories.\n  echo \"Listing SourcePackages directory for firebase-ios-sdk:\"\n  find \"${SCRIPT_BASE}/SourcePackages/checkouts\" -type d -name \"firebase-ios-sdk\" -print\n  exit 1\nfi\n";
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/sh\n# Use the local copy of the Crashlytics run script located in your project.\n# If your Xcode project is in the ParentingAssistant folder, then SRCROOT is that folder.\nSCRIPT_PATH=\"${SRCROOT}/FirebaseCrashlytics/run\"\n\necho \"Resolved Crashlytics run script path: ${SCRIPT_PATH}\"\necho \"Listing contents of ${SRCROOT}/FirebaseCrashlytics:\"\nls -la \"${SRCROOT}/FirebaseCrashlytics\"\n\nif [ -f \"${SCRIPT_PATH}\" ]; then\n  # Ensure the script is executable.\n  chmod +x \"${SCRIPT_PATH}\"\n  echo \"Executing Crashlytics run script...\"\n  \"${SCRIPT_PATH}\"\nelse\n  echo \"Error: Crashlytics run script not found at: ${SCRIPT_PATH}\"\n  exit 1\nfi\n";
+			disableDefaultSettings = 1;
+			enableUserScriptSandboxing = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -479,6 +489,7 @@
 				DEVELOPMENT_TEAM = VMXQN9K3P2;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -519,6 +530,7 @@
 				DEVELOPMENT_TEAM = VMXQN9K3P2;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;

--- a/ParentingAssistant/ParentingAssistant/FirebaseCrashlytics/run.txt
+++ b/ParentingAssistant/ParentingAssistant/FirebaseCrashlytics/run.txt
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+# Copyright 2019 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# run
+#
+# This script is meant to be run as a Run Script in the "Build Phases" section
+# of your Xcode project. It sends debug symbols to symbolicate stacktraces,
+# sends build events to track versions, and onboards apps for Crashlytics.
+#
+# This script calls upload-symbols twice:
+#
+# 1) First it calls upload-symbols synchronously in "validation" mode. If the
+#    script finds issues with the build environment, it will report errors to Xcode.
+#    In validation mode it exits before doing any time consuming work.
+#
+# 2) Then it calls upload-symbols in the background to actually send the build
+#    event and upload symbols. It does this in the background so that it doesn't
+#    slow down your builds. If an error happens here, you won't see it in Xcode.
+#
+# You can find the output for the background execution in Console.app, by
+# searching for "upload-symbols".
+#
+# If you want verbose output, you can pass the --debug flag to this script
+#
+
+#  Figure out where we're being called from
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+#  Build up the arguments list, passing through any flags added, and quoting
+#  every argument in case there are spaces in any of the paths.
+ARGUMENTS=''
+for i in "$@"; do
+  ARGUMENTS="$ARGUMENTS \"$i\""
+done
+
+VALIDATE_ARGUMENTS="--build-phase --validate $ARGUMENTS"
+UPLOAD_ARGUMENTS="--build-phase $ARGUMENTS "
+
+# Quote the path to handle folders with special characters
+COMMAND_PATH="\"$DIR/upload-symbols\" "
+
+#  Ensure params are as expected, run in sync mode to validate,
+#  and cause a build error if validation fails
+eval $COMMAND_PATH$VALIDATE_ARGUMENTS
+return_code=$?
+
+if [[ $return_code != 0 ]]; then
+  exit $return_code
+fi
+
+#  Verification passed, convert and upload dSYMs in the background to prevent
+#  build delays
+#
+#  Note: Validation is performed again at this step before upload
+#
+#  Note: Output can still be found in Console.app, by searching for
+#        "upload-symbols"
+#
+eval $COMMAND_PATH$UPLOAD_ARGUMENTS > /dev/null 2>&1 &

--- a/ParentingAssistant/ParentingAssistant/ParentingAssistant.entitlements
+++ b/ParentingAssistant/ParentingAssistant/ParentingAssistant.entitlements
@@ -6,6 +6,10 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
+    <key>com.apple.security.files.downloads.read-only</key>
+    <true/>
+    <key>com.apple.security.files.downloads.read-write</key>
+    <true/>
     <key>keychain-access-groups</key>
     <array>
         <string>$(AppIdentifierPrefix)com.yourcompany.parentingassistant</string>

--- a/ParentingAssistant/ParentingAssistant/ParentingAssistant.entitlements
+++ b/ParentingAssistant/ParentingAssistant/ParentingAssistant.entitlements
@@ -10,6 +10,10 @@
     <true/>
     <key>com.apple.security.files.downloads.read-write</key>
     <true/>
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
+    <key>com.apple.security.files.bookmarks.document-scope</key>
+    <true/>
     <key>keychain-access-groups</key>
     <array>
         <string>$(AppIdentifierPrefix)com.yourcompany.parentingassistant</string>


### PR DESCRIPTION
This pull request introduces significant changes to integrate Firebase Crashlytics into the ParentingAssistant project. The changes include adding a new run script for Crashlytics, updating the project configuration, and modifying entitlements.

### Integration of Firebase Crashlytics:

* Added a new run script `run` for Firebase Crashlytics, which uploads debug symbols and tracks build events. This script is intended to be used in the "Build Phases" section of the Xcode project. (`ParentingAssistant/FirebaseCrashlytics/run`, `ParentingAssistant/FirebaseCrashlytics/run.txt`)
* Updated the Xcode project file to include the FirebaseCrashlytics group and configured the build phase to execute the Crashlytics run script. (`ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R73-R77) [[2]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R115) [[3]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R160) [[4]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892L310-R320)
* Disabled user script sandboxing in the project settings to allow the Crashlytics script to run without restrictions. (`ParentingAssistant/ParentingAssistant.xcodeproj/project.pbxproj`) [[1]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R492) [[2]](diffhunk://#diff-0e83b33b24c4bb85bc6fef3c02074acb9e05277eb596af5de78d0b5e612a6892R533)

### Entitlements Update:

* Modified the entitlements file to include permissions for accessing user-selected files, downloads, and bookmarks. (`ParentingAssistant/ParentingAssistant/ParentingAssistant.entitlements`)